### PR TITLE
Remove specific implementer/static backend url

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "main": "src/index.ts",
   "source": true,
   "scripts": {
-    "start": "openmrs develop --backend https://ugandaemr-backend.mets.or.ug",
+    "start": "openmrs develop",
     "serve": "webpack serve --mode=development",
     "build": "webpack --mode production",
     "analyze": "webpack --mode=production --env analyze=true",


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
I think it is good to have this as non static url for one to specify his/her backend url during dev. This is also inline with our vision of going OpenMRS community way for the stock management module

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
