### PR TITLE
(feat) Pre-Populate stock issue table based on requisition

### DIFF
--- a/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
+++ b/src/stock-operations/add-stock-operation/add-stock-operation.component.tsx
@@ -21,6 +21,7 @@ import StockOperationPrintButton from "../stock-operations-dialog/stock-operatio
 import StockOperationApproveDispatchButton from "../stock-operations-dialog/stock-operations-approve-dispatch-button.component";
 import StockOperationCompleteDispatchButton from "../stock-operations-dialog/stock-operations-completed-dispatch-button.component";
 import StockOperationIssueStockButton from "../stock-operations-dialog/stock-operations-issue-stock-button.component";
+import { StockOperation } from "./stock-operation-context/useStockOperationContext";
 
 const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
   const { t } = useTranslation();
@@ -258,11 +259,13 @@ const AddStockOperation: React.FC<AddStockOperationProps> = (props) => {
           </div>
         )}
       </div>
-      <VerticalTabs
-        tabs={tabs}
-        selectedIndex={selectedIndex}
-        onChange={setSelectedIndex}
-      />
+      <StockOperation>
+        <VerticalTabs
+          tabs={tabs}
+          selectedIndex={selectedIndex}
+          onChange={setSelectedIndex}
+        />
+      </StockOperation>
     </>
   );
 };

--- a/src/stock-operations/add-stock-operation/base-operation-details.component.tsx
+++ b/src/stock-operations/add-stock-operation/base-operation-details.component.tsx
@@ -35,6 +35,8 @@ import { InitializeResult } from "./types";
 import rootStyles from "../../root.scss";
 import { ResourceRepresentation } from "../../core/api/api";
 import { useStockOperationPages } from "../stock-operations-table.resource";
+import { StockOperationItemDTO } from "../../core/api/types/stockOperation/StockOperationItemDTO";
+import { useStockOperationContext } from "./stock-operation-context/useStockOperationContext";
 
 interface BaseOperationDetailsProps {
   isEditing?: boolean;
@@ -60,6 +62,7 @@ const BaseOperationDetails: React.FC<BaseOperationDetailsProps> = ({
   },
 }) => {
   const { t } = useTranslation();
+  const { formContext, setFormContext } = useStockOperationContext();
   const { isLoading, items } = useStockOperationPages({
     v: ResourceRepresentation.Full,
     totalCount: true,
@@ -190,6 +193,13 @@ const BaseOperationDetails: React.FC<BaseOperationDetailsProps> = ({
                 {...field}
                 onChange={(data: { selectedItem: StockOperationDTO }) => {
                   field.onChange(data.selectedItem.uuid);
+                  Object.assign(
+                    model.stockOperationItems,
+                    data.selectedItem.stockOperationItems
+                  );
+                  setFormContext({
+                    stockItems: data.selectedItem.stockOperationItems,
+                  });
                 }}
                 itemToElement={(item) => {
                   return item?.operationNumber ?? "";

--- a/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition-row.component.tsx
@@ -263,7 +263,7 @@ const StockItemsAdditionRow: React.FC<StockItemsAdditionRowProps> = ({
                     setValue(`stockItems.${index}.quantity`, e?.target?.value)
                   }
                   value={row?.quantity ?? ""}
-                  invalidText=""
+                  invalidText={errors?.stockItems?.[index]?.quantity?.message}
                   placeholder={
                     requiresBatchUuid &&
                     !requiresActualBatchInformation &&

--- a/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
@@ -100,7 +100,7 @@ const StockItemsAddition: React.FC<StockItemsAdditionProps> = ({
 
   useEffect(() => {
     if (formContext?.stockItems) {
-      const stockItems = formContext?.stockItems as Array<any>;
+      const stockItems = formContext?.stockItems as Array<StockOperationItemDTO>;
       stockItems?.forEach((item) => append(item));
     }
   }, [append, formContext?.stockItems]);

--- a/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { StockOperationDTO } from "../../core/api/types/stockOperation/StockOperationDTO";
 import { SaveStockOperation } from "../../stock-items/types";
 import { StockOperationType } from "../../core/api/types/stockOperation/StockOperationType";
@@ -31,6 +31,7 @@ import { Add, ArrowRight } from "@carbon/react/icons";
 import styles from "./stock-items-addition.component.scss";
 import { errorAlert } from "../../core/utils/alert";
 import { z } from "zod";
+import { useStockOperationContext } from "./stock-operation-context/useStockOperationContext";
 
 interface StockItemsAdditionProps {
   isEditing?: boolean;
@@ -59,6 +60,7 @@ const StockItemsAddition: React.FC<StockItemsAdditionProps> = ({
 }) => {
   const { t } = useTranslation();
   const { operationType } = operation ?? {};
+  const { formContext, setFormContext } = useStockOperationContext();
   const validationSchema = useValidationSchema(operationType);
   const handleSave = async (item: { stockItems: StockOperationItemDTO[] }) => {
     if (item.stockItems.length == 0) {
@@ -95,6 +97,13 @@ const StockItemsAddition: React.FC<StockItemsAdditionProps> = ({
     name: "stockItems",
     control,
   });
+
+  useEffect(() => {
+    if (formContext?.stockItems) {
+      const stockItems = formContext?.stockItems as Array<any>;
+      stockItems?.forEach((item) => append(item));
+    }
+  }, [append, formContext?.stockItems]);
 
   const headers = [
     {

--- a/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
+++ b/src/stock-operations/add-stock-operation/stock-items-addition.component.tsx
@@ -100,7 +100,8 @@ const StockItemsAddition: React.FC<StockItemsAdditionProps> = ({
 
   useEffect(() => {
     if (formContext?.stockItems) {
-      const stockItems = formContext?.stockItems as Array<StockOperationItemDTO>;
+      const stockItems =
+        formContext?.stockItems as Array<StockOperationItemDTO>;
       stockItems?.forEach((item) => append(item));
     }
   }, [append, formContext?.stockItems]);

--- a/src/stock-operations/add-stock-operation/stock-operation-context/useStockOperationContext.tsx
+++ b/src/stock-operations/add-stock-operation/stock-operation-context/useStockOperationContext.tsx
@@ -1,0 +1,22 @@
+import React, { createContext, useContext, useState } from "react";
+
+type StockOperationShape = {
+  formContext: Record<string, unknown>;
+  setFormContext: (formValue) => void;
+};
+
+const StockOperationContext = createContext<StockOperationShape>(null);
+
+export const useStockOperationContext = () => useContext(StockOperationContext);
+
+export const StockOperation: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const [formContext, setFormContext] = useState<StockOperationShape>(null);
+  const value = { formContext, setFormContext };
+  return (
+    <StockOperationContext.Provider value={value}>
+      {children}
+    </StockOperationContext.Provider>
+  );
+};


### PR DESCRIPTION
(feat) Pre-Populate stock issue table based on requisition contents of the requisition. (Stock Issue Operation)

## Requirements
- [X ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ X]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [X ] My work includes tests or is validated by existing tests.

## Summary
When creating a new stock issue based on a requisition, pre-populate the table with all the items in the requisition

## Screenshots

![Issue 2 2024-01-15 16-06-00](https://github.com/METS-Programme/esm-ugandaemr-stock-management/assets/97954453/3083087a-8e7f-4e26-ad78-d85cc2e27a28)
![Issue 1 2024-01-15 16-04-49](https://github.com/METS-Programme/esm-ugandaemr-stock-management/assets/97954453/81ca44d8-fcbf-4f6b-8067-fc17edd7c559)


## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
