### PR TITLE
Remove debounce from batch no selector. Already set by item selector

### DIFF
--- a/src/stock-operations/batch-no-selector/batch-no-selector.component.tsx
+++ b/src/stock-operations/batch-no-selector/batch-no-selector.component.tsx
@@ -1,10 +1,8 @@
 import React, { ReactNode, useMemo } from "react";
 import { Control, Controller, FieldValues } from "react-hook-form";
 import { ComboBox, InlineLoading } from "@carbon/react";
-import { useDebounce } from "../../core/hooks/debounce-hook";
 import { useStockItemBatchNos } from "./batch-no-selector.resource";
 import { StockBatchDTO } from "../../core/api/types/stockItem/StockBatchDTO";
-import first from "lodash-es/first";
 
 interface BatchNoSelectorProps<T> {
   placeholder?: string;
@@ -22,8 +20,9 @@ interface BatchNoSelectorProps<T> {
 }
 
 const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
-  const { isLoading, stockItemBatchNos, setSearchString } =
-    useStockItemBatchNos(props.stockItemUuid);
+  const { isLoading, stockItemBatchNos } = useStockItemBatchNos(
+    props.stockItemUuid
+  );
   const initialSelectedItem = useMemo(
     () =>
       stockItemBatchNos?.find(
@@ -31,10 +30,6 @@ const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
       ) ?? "",
     [stockItemBatchNos, props.batchUuid]
   );
-
-  const debouncedSearch = useDebounce((query: string) => {
-    setSearchString(query);
-  }, 500);
 
   if (isLoading) return <InlineLoading status="active" />;
 
@@ -69,7 +64,6 @@ const BatchNoSelector = <T,>(props: BatchNoSelectorProps<T>) => {
             placeholder={props.placeholder}
             invalid={props.invalid}
             invalidText={props.invalidText}
-            onInputChange={debouncedSearch}
             ref={ref}
           />
         )}


### PR DESCRIPTION
## Requirements
- [ ] This PR has a title that briefly describes the work done including a [conventional commit](https://o3-dev.docs.openmrs.org/#/getting_started/contributing?id=your-pr-title-should-indicate-the-type-of-change-it-is) type prefix and a Jira ticket number if applicable. See existing PR titles for inspiration.

#### For changes to apps
- [ ]  My work conforms to the [**OpenMRS 3.0 Styleguide**](https://om.rs/styleguide) and [**design documentation**](https://zeroheight.com/23a080e38/p/880723-introduction).

#### If applicable
- [ ] My work includes tests or is validated by existing tests.

## Summary
<!-- Please describe what problems your PR addresses. -->
When an item is selected batch number is also fetched. There is no need of a debounce in while selecting a batch making unnecessary search

## Screenshots
<!-- Required if you are making UI changes. -->
<!-- *None* -->

## Related Issue
<!-- Paste the link to the Jira ticket here if one exists. -->
<!-- https://issues.openmrs.org/browse/O3- -->
<!-- *None* -->

## Other
<!-- Anything not covered above -->
<!-- *None* -->
